### PR TITLE
Reverse order of the history list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,7 +130,7 @@ export const History: React.FC<HistoryProps> = ({ history }) => {
 		<table>
 			<tbody>
 				{history &&
-					history.map((r, k) => (
+					history.reverse().map((r, k) => (
 						<tr key={k}>
 							<td>{r.from}</td>
 							<td>{"->"}</td>


### PR DESCRIPTION
Reverse the order of history so most recent move is at the top of the list.